### PR TITLE
Add whitespace normalization helper to punkt tokenizer

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1829,3 +1829,8 @@ def demo(text, tok_cls=PunktSentenceTokenizer, train_cls=PunktTrainer):
     sbd = tok_cls(trainer.get_params())
     for sentence in sbd.sentences_from_text(text):
         print(cleanup(sentence))
+
+
+def _normalize_whitespace(text):
+    """Collapse multiple whitespace characters into a single space."""
+    return " ".join(text.split())


### PR DESCRIPTION
Adds a small utility function to normalize whitespace in text before sentence tokenization. This collapses runs of spaces, tabs, and newlines into single spaces, which avoids edge cases in the Punkt algorithm when input contains irregular whitespace.